### PR TITLE
Reset media player when setting video source

### DIFF
--- a/vidsta/src/main/java/uk/co/jakelee/vidsta/VidstaPlayer.java
+++ b/vidsta/src/main/java/uk/co/jakelee/vidsta/VidstaPlayer.java
@@ -373,6 +373,7 @@ public class VidstaPlayer extends FrameLayout implements TextureView.SurfaceText
         }
         videoPlayer.setSurface(surface);
         try {
+            videoPlayer.reset();
             videoPlayer.setDataSource(getContext(), videoSource, headers);
             videoPlayer.prepareAsync();
         } catch (IOException e) {


### PR DESCRIPTION
Call reset() to reset the media player to idle state, before setting a new video source.

This will resolve #3 