### PR TITLE
Update ids.xml

### DIFF
--- a/vidsta/src/main/res/values/ids.xml
+++ b/vidsta/src/main/res/values/ids.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <item name="touchId" type="id">2564</item>
+    <item name="touchId" type="id"/>
 </resources>


### PR DESCRIPTION
Newest gradle update has caused this:
`error: <item> inner element must either be a resource reference or empty.`
I have tracked it down to this single `<item>`.